### PR TITLE
Add option to disable prepending MEDIA_URL to filename in AjaxImageField

### DIFF
--- a/ajaximage/static/ajaximage/js/ajaximage.js
+++ b/ajaximage/static/ajaximage/js/ajaximage.js
@@ -35,7 +35,7 @@ $(function(){
         $(el).find('.link').attr('href', data.result.url)
         $(el).find('img').attr('src', data.result.url)
         $(el).attr('class', 'ajaximage img-active')
-        $(el).find('input[type=hidden]').val(data.result.url)
+        $(el).find('input[type=hidden]').val(data.result.filename)
         $(el).find('.bar').css({width: '0%'})
       }
     })

--- a/ajaximage/views.py
+++ b/ajaximage/views.py
@@ -11,6 +11,7 @@ from ajaximage.forms import FileForm
 
 
 UPLOAD_PATH = getattr(settings, 'AJAXIMAGE_DIR', 'ajaximage/')
+PREPEND_MEDIA_URL = getattr(settings, 'AJAXIMAGE_PREPEND_MEDIA_URL', True)
 
 
 @csrf_exempt
@@ -33,5 +34,10 @@ def ajaximage(request, upload_to=None, max_width=None, max_height=None, crop=Non
         file_path = default_storage.save(os.path.join(upload_to or UPLOAD_PATH, safe_name), file_)
         url = os.path.join(settings.MEDIA_URL, file_path)
         
-        return HttpResponse(json.dumps({'url': url}))
+        if PREPEND_MEDIA_URL:
+            filename = url
+        else:
+            filename = file_path
+        
+        return HttpResponse(json.dumps({'url': url, 'filename': filename}))
     return HttpResponse(status=403)

--- a/ajaximage/widgets.py
+++ b/ajaximage/widgets.py
@@ -5,12 +5,13 @@ from django.core.urlresolvers import reverse
 from django.utils import simplejson as json
 from django.conf import settings
 
+PREPEND_MEDIA_URL = getattr(settings, 'AJAXIMAGE_PREPEND_MEDIA_URL', True)
 
 HTML = """
 <div class="ajaximage" data-url="{upload_url}">
     <a class="link" target="_blank" href="{file_url}"><img src="{file_url}"></a>
     <a class="remove" href="#remove">Remove</a>
-    <input type="hidden" value="{file_url}" id="{element_id}" name="{name}" />
+    <input type="hidden" value="{file_path}" id="{element_id}" name="{name}" />
     <input type="file" class="fileinput" />
     <div class="progress progress-striped active">
         <div class="bar"></div>
@@ -43,7 +44,6 @@ class AjaxImageEditor(widgets.TextInput):
         self.crop = kwargs.pop('crop', '')
         super(AjaxImageEditor, self).__init__(*args, **kwargs)
 
-
     def render(self, name, value, attrs=None):
         final_attrs = self.build_attrs(attrs)
         element_id = final_attrs.get('id')
@@ -54,12 +54,18 @@ class AjaxImageEditor(widgets.TextInput):
                   'crop': self.crop}
         
         upload_url = reverse('ajaximage', kwargs=kwargs)
-        file_url = value if value else ''
+        file_path = value if value else ''
+        if PREPEND_MEDIA_URL is False and len(file_path) > 0:
+            file_url = os.path.join(settings.MEDIA_URL, file_path)
+        else:
+            file_url = file_path
+
         file_name = os.path.basename(file_url)
         
         output = HTML.format(upload_url=upload_url,
                              file_url=file_url,
                              file_name=file_name,
+                             file_path=file_path,
                              element_id=element_id,
                              name=name)
         


### PR DESCRIPTION
This allows developers to add `AJAXIMAGE_PREPEND_MEDIA_URL = False` to their Django settings, which will make the AjaxImageField act more like FileField / ImageField (i.e. the value of the field will be a path relative to `MEDIA_URL`). 
