### PR TITLE
Adding unicode, before mark_safe

### DIFF
--- a/ajaximage/widgets.py
+++ b/ajaximage/widgets.py
@@ -63,4 +63,4 @@ class AjaxImageEditor(widgets.TextInput):
                              element_id=element_id,
                              name=name)
         
-        return mark_safe(output)
+        return mark_safe(unicode(output))


### PR DESCRIPTION
The mark_safe does not work, as it suppose to. Need to force unicode(), to force mark_safe().

More info: http://stackoverflow.com/questions/2597184/django-odd-mark-safe-behaviour
