### PR TITLE
Upload_to may now be a function

### DIFF
--- a/ajaximage/widgets.py
+++ b/ajaximage/widgets.py
@@ -44,13 +44,6 @@ class AjaxImageWidget(widgets.TextInput):
         final_attrs = self.build_attrs(attrs)
         element_id = final_attrs.get('id')
 
-        kwargs = {'upload_to': self.upload_to,
-                  'max_width': self.max_width,
-                  'max_height': self.max_height,
-                  'crop': self.crop}
-
-        upload_url = reverse('ajaximage', kwargs=kwargs)
-
         # NB convert to string and do not rely on value.url
         # value.url fails when rendering form with validation errors because
         # form value is not a FieldFile. Use storage.url and file_path - works
@@ -59,6 +52,19 @@ class AjaxImageWidget(widgets.TextInput):
         file_url = default_storage.url(file_path) if value else ''
 
         file_name = os.path.basename(file_url)
+
+        if hasattr(self.upload_to, '__call__'):
+            try:
+                self.upload_to = self.upload_to(value.instance, file_name)
+            except AttributeError:
+                self.upload_to = self.upload_to(None, file_name)
+
+        kwargs = {'upload_to': self.upload_to,
+                  'max_width': self.max_width,
+                  'max_height': self.max_height,
+                  'crop': self.crop}
+
+        upload_url = reverse('ajaximage', kwargs=kwargs)
 
         output = self.html.format(upload_url=upload_url,
                              file_url=file_url,

--- a/example/kitten/models.py
+++ b/example/kitten/models.py
@@ -1,10 +1,15 @@
+import random
 from django.db import models
 from ajaximage.fields import AjaxImageField
 
 
+def random_folder(instance, filename):
+    return 'thumbs_{}/{}'.format(random.randint(0, 50), filename)
+
+
 class Kitten(models.Model):
     image = AjaxImageField()
-    thumbnail = AjaxImageField(upload_to='thumbnails', max_height=200,
+    thumbnail = AjaxImageField(upload_to=random_folder, max_height=200,
                                max_width=200, crop=False)
 
     def __unicode__(self):


### PR DESCRIPTION
I didn't really test this against older Python/Django versions, but I guess it should work as is.
I didn't try either with another type of callable than a function.

I updated the Kitten example, the thumbnails are now put in a random directory (feel free to remove this, of course).

The `instance` parameter is only available if there is one, as it is done in https://docs.djangoproject.com/fr/1.9/ref/models/fields/#django.db.models.FileField.upload_to.

Hope it helps