### PR TITLE
add django 1.10 support

### DIFF
--- a/ajaximage/urls.py
+++ b/ajaximage/urls.py
@@ -1,13 +1,25 @@
 try:  # pre 1.6
     from django.conf.urls.defaults import url, patterns
 except ImportError:
-    from django.conf.urls import url, patterns
+	try:
+	    from django.conf.urls import url, patterns
+	    urlpatterns = patterns(
+		    '',
+		    url(
+		        '^upload/(?P<upload_to>.*)/(?P<max_width>\d+)/(?P<max_height>\d+)/(?P<crop>\d+)',
+		        'ajaximage.views.ajaximage',
+		        name='ajaximage'
+		    ),
+		)
+	except ImportError:
+		# django 1.10
+		from django.conf.urls import url	
+		from ajaximage.views import ajaximage
+		urlpatterns = [
+		    url(
+		        '^upload/(?P<upload_to>.*)/(?P<max_width>\d+)/(?P<max_height>\d+)/(?P<crop>\d+)',
+		        ajaximage,
+		        name='ajaximage'
+		    ),
+		]
 
-urlpatterns = patterns(
-    '',
-    url(
-        '^upload/(?P<upload_to>.*)/(?P<max_width>\d+)/(?P<max_height>\d+)/(?P<crop>\d+)',
-        'ajaximage.views.ajaximage',
-        name='ajaximage'
-    ),
-)

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -57,5 +57,23 @@ MEDIA_URL = '/media/'
 
 TEMPLATE_DIRS = (os.path.join(BASE_DIR, 'templates'),)
 
+# django 1.10
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': ['templates'],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+
 AJAXIMAGE_DIR = 'ajaximage/'
 AJAXIMAGE_AUTH_TEST = lambda u: True

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
@@ -6,11 +6,21 @@ from django.contrib import admin
 
 admin.autodiscover()
 
-
-urlpatterns = patterns('',
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^ajaximage/', include('ajaximage.urls')),
-    url(r'^form/', include('kitten.urls')),
-)
+try:
+	from django.conf.urls import patterns, include, url
+	urlpatterns = patterns('',
+	    url(r'^admin/', include(admin.site.urls)),
+	    url(r'^ajaximage/', include('ajaximage.urls')),
+	    url(r'^form/', include('kitten.urls')),
+	)
+except ImportError:
+	# django 1.10
+	from django.conf.urls import include, url
+	urlpatterns = [
+	    url(r'^admin/', include(admin.site.urls)),
+	    url(r'^ajaximage/', include('ajaximage.urls')),
+	    url(r'^form/', include('kitten.urls')),
+	]
+	
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/example/kitten/urls.py
+++ b/example/kitten/urls.py
@@ -1,8 +1,13 @@
-from django.conf.urls import patterns, url
-
 from .views import MyView
 
-
-urlpatterns = patterns('',
-    url('', MyView.as_view(), name='form'),
-)
+try:
+	from django.conf.urls import patterns, url
+	urlpatterns = patterns('',
+	    url('', MyView.as_view(), name='form'),
+	)
+except ImportError:
+  	# django 1.10
+	from django.conf.urls import url
+	urlpatterns = [
+	    url('', MyView.as_view(), name='form'),
+	]


### PR DESCRIPTION
As `patterns` is removed from `django.conf.urls` in `django 1.10` `django-ajaximage` raised Exceptions.

In this commit it is maintained support for previous versions of django

Did manual testing on `django` versions:

* 1.9
* 1.8
* 1.7

and added support for `django 1.10`
Example application is also modified to work for all versions.

