### PR TITLE
Optimize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.pyc
 *.DS_Store
 dist/*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Features Appended:
 * Support django2 and above
 * `upload_to` support datetime string format
 * Change FileField to ImageFileField to compatible with ImageField
+* Add format_image method to display custom image field using the same format
+    ```
+from ajaximage.utils import format_image
+class xxxAdmin(ModelAdmin):
+    ...
+    def some_field(obj):
+        return format_image(obj.some_field.ajaximagefiled)      
+    ```
 
 ![screenshot](/screenshot.png?raw=true)
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Features Appended:
 * Change FileField to ImageFileField to compatible with ImageField
 * Add format_image method to display custom image field using the same format
     ```
-from ajaximage.utils import format_image
-class xxxAdmin(ModelAdmin):
-    ...
-    def some_field(obj):
-        return format_image(obj.some_field.ajaximagefiled)      
+    from ajaximage.utils import format_image
+    class xxxAdmin(ModelAdmin):
+        ...
+        def some_field(obj):
+            return format_image(obj.some_field.ajaximagefiled)      
     ```
 
 ![screenshot](/screenshot.png?raw=true)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Ajax image uploads.
 
 Upload images via ajax. Images are optionally resized.
 
+Optimize on https://github.com/bradleyg/django-ajaximage.
+
+Features Appended:
+
+* Correctly display the readonly field
+* Support django2 and above
+* `upload_to` support datetime string format
+* Change FileField to ImageFileField to compatible with ImageField
+
 ![screenshot](/screenshot.png?raw=true)
 
 ## Support
@@ -38,9 +47,9 @@ AJAXIMAGE_AUTH_TEST = lambda u: True
 ### urls.py
 
 ```python
-urlpatterns = patterns('',
-    url(r'^ajaximage/', include('ajaximage.urls')),
-)
+urlpatterns += [
+    path('ajaximage/', include('ajaximage.urls')),
+]
 ```
 
 Run ```python manage.py collectstatic``` if required.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Features Appended:
     class xxxAdmin(ModelAdmin):
         ...
         def some_field(obj):
-            return format_image(obj.some_field.ajaximagefiled)      
+            return format_image(obj.some_field.ajaximagefield)      
     ```
 
 ![screenshot](/screenshot.png?raw=true)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ajax image uploads.
 
 Upload images via ajax. Images are optionally resized.
 
-Optimize on https://github.com/bradleyg/django-ajaximage.
+Optimized on https://github.com/bradleyg/django-ajaximage.
 
 Features Appended:
 

--- a/ajaximage/fields.py
+++ b/ajaximage/fields.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import django.contrib.admin.helpers
+from ajaximage.utils import format_image
 from django.contrib.admin.utils import display_for_field
 from django.core.files.storage import default_storage
 from django.db.models import Field
@@ -57,8 +58,7 @@ class AjaxImageField(Field):
 def display_for_field_patch(value, field, empty_value_display):
     if isinstance(field, AjaxImageField) and value:
         width = value.width if value.width < 200 else 200
-        return mark_safe(f"""<a target="_blank" href="{value.url}">
-    <img width="{width}px" src="{value.url}"></a>""")
+        return format_image(value)
     else:
         return display_for_field(value, field, empty_value_display)
 

--- a/ajaximage/fields.py
+++ b/ajaximage/fields.py
@@ -1,15 +1,17 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
+import django.contrib.admin.helpers
+from django.contrib.admin.utils import display_for_field
 from django.core.files.storage import default_storage
-from django.db.models.fields.files import FileDescriptor, FieldFile
 from django.db.models import Field
-from django.conf import settings
+from django.db.models.fields.files import FileDescriptor, ImageFieldFile
+from django.utils.safestring import mark_safe
+
 from .widgets import AjaxImageWidget
 
 
 class AjaxImageField(Field):
-
     storage = default_storage
-    attr_class = FieldFile
+    attr_class = ImageFieldFile
     descriptor_class = FileDescriptor
 
     def __init__(self, *args, **kwargs):
@@ -50,6 +52,15 @@ class AjaxImageField(Field):
         return super(AjaxImageField, self).formfield(**defaults)
 
 
-if 'south' in settings.INSTALLED_APPS:
-    from south.modelsinspector import add_introspection_rules
-    add_introspection_rules([], ["^ajaximage\.fields\.AjaxImageField"])
+# Monkey path to rightly display readonly field.
+
+def display_for_field_patch(value, field, empty_value_display):
+    if isinstance(field, AjaxImageField) and value:
+        width = value.width if value.width < 200 else 200
+        return mark_safe(f"""<a target="_blank" href="{value.url}">
+    <img width="{width}px" src="{value.url}"></a>""")
+    else:
+        return display_for_field(value, field, empty_value_display)
+
+
+django.contrib.admin.helpers.display_for_field = display_for_field_patch

--- a/ajaximage/utils.py
+++ b/ajaximage/utils.py
@@ -1,0 +1,10 @@
+# coding: utf-8
+from django.utils.safestring import mark_safe
+
+
+def format_image(ajax_image_file_field):
+    if ajax_image_file_field:
+        width = ajax_image_file_field.width if ajax_image_file_field.width < 200 else 200
+        html = f"""<a class="file-link" target="_blank" href="{ajax_image_file_field.url}">
+    <img width="{width}px" src="{ajax_image_file_field.url}"></a>"""
+        return mark_safe(html)

--- a/ajaximage/views.py
+++ b/ajaximage/views.py
@@ -1,15 +1,16 @@
-import os
+import datetime
 import json
+import os
+
 from django.conf import settings
 from django.contrib.auth.decorators import user_passes_test
 from django.core.files.storage import default_storage
 from django.http import HttpResponse
 from django.utils.text import slugify
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
-from .image import resize
-from .forms import FileForm
 
+from .forms import FileForm
+from .image import resize
 
 UPLOAD_PATH = getattr(settings, 'AJAXIMAGE_DIR', 'ajaximage/')
 AUTH_TEST = getattr(settings, 'AJAXIMAGE_AUTH_TEST', lambda u: u.is_staff)
@@ -33,7 +34,8 @@ def ajaximage(request, upload_to=None, max_width=None, max_height=None, crop=Non
         file_ = resize(file_, max_width, max_height, crop)
         file_name, extension = os.path.splitext(file_.name)
         safe_name = '{0}{1}'.format(FILENAME_NORMALIZER(file_name), extension)
-
+        if upload_to:
+            upload_to = datetime.datetime.now().strftime(upload_to)
         name = os.path.join(upload_to or UPLOAD_PATH, safe_name)
         path = default_storage.save(name, file_)
         url = default_storage.url(path)

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,14 @@ readme = f.read()
 f.close()
 
 setup(
-    name='django-ajaximage',
-    version='0.2.9',
-    description='Upload images via ajax. Images are optionally resized.',
+    name='django2-ajaximage',
+    version='0.6.0',
+    description='Upload images via ajax. Images are optionally resized.',    
     long_description=readme,
-    author="Bradley Griffiths",
+    long_description_content_type='text/markdown',
+    author="Bradley Griffiths(Modified by Daimon)",
     author_email='bradley.griffiths@gmail.com',
-    url='https://github.com/bradleyg/django-ajaximage',
+    url='https://github.com/bradleyg/django2-ajaximage',
     packages=['ajaximage'],
     include_package_data=True,
     install_requires=['Django', 'Pillow',],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ f.close()
 
 setup(
     name='django2-ajaximage',
-    version='0.6.0',
+    version='0.7.0',
     description='Upload images via ajax. Images are optionally resized.',    
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I don't know wheather you maintain this package or not. But I think it is the best image field in django.
I made some updates on it. Maybe you need it too.

* Correctly display the readonly field(Monkey patch django helper module)
* Support django2 and above
* upload_to support datetime string format
* Change FileField to ImageFileField to compatible with ImageField
* Add format_image method to display custom image field using the same format
